### PR TITLE
Bump minimum python version to 3.14

### DIFF
--- a/.github/workflows/test_and_lint_python_package.yml
+++ b/.github/workflows/test_and_lint_python_package.yml
@@ -17,7 +17,7 @@ jobs:
     permissions:
       contents: read
     with:
-      python-versions: '["3.12", "3.13", "3.14"]'
+      python-versions: '["3.14"]'
       run-black: true
       run-mypy: true
       run-ruff: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim AS build
+FROM python:3.14-slim AS build
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
@@ -22,7 +22,7 @@ RUN uv sync --frozen --no-dev --no-install-project
 COPY . .
 RUN --mount=source=.git,target=.git,type=bind uv sync --frozen --no-dev
 
-FROM python:3.13-slim
+FROM python:3.14-slim
 
 WORKDIR /app
 COPY --from=build /app/.venv /app/.venv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "sara-timeseries"
 authors = [{ name = "Equinor ASA", email = "fg_robots_dev@equinor.com" }]
 description = "Component for uploading datapoints to Omnia Timeseries"
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.14"
 license = {file = "LICENSE"}
 classifiers = [
   "Intended Audience :: Developers",
@@ -15,11 +15,7 @@ classifiers = [
   "License :: OSI Approved :: MIT License",
   "Natural Language :: English",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.9",
-  "Programming Language :: Python :: 3.10",
-  "Programming Language :: Python :: 3.11",
-  "Programming Language :: Python :: 3.12",
-  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Topic :: Scientific/Engineering",
   "Topic :: Scientific/Engineering :: Physics",
   "Topic :: Software Development :: Libraries",


### PR DESCRIPTION
## Summary
- Bump `requires-python` to `>=3.14` and remove stale classifiers
- Update CI to test on Python 3.14 only
- Update Dockerfile to `python:3.14-slim`
- Add `AGENTS.md` to `.gitignore`