### PR TITLE
Add --no-editable to Dockerfile uv sync

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ COPY pyproject.toml uv.lock ./
 RUN uv sync --frozen --no-dev --no-install-project
 
 COPY . .
-RUN --mount=source=.git,target=.git,type=bind uv sync --frozen --no-dev
+RUN --mount=source=.git,target=.git,type=bind uv sync --frozen --no-editable --no-dev
 
 FROM python:3.14-slim
 


### PR DESCRIPTION
## Summary
- Add `--no-editable` flag to the second `uv sync` in the multi-stage Dockerfile
- Without this flag, uv creates editable `.pth` files in `.venv` pointing to source directories in the build stage. The runtime stage only copies `.venv`, so the references break and cause `ModuleNotFoundError: No module named 'sara_timeseries'` at runtime.