### PR TITLE
Use DefaultAzureCredential for blob storage (Workload Identity in AKS)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # Client secret for the Timeseries API
 SARA_TIMESERIES_TIMESERIES_CLIENT_SECRET=
-# Client secret for autheticating to use this API
+# Optional: only required when "ClientSecret" is in SARA_TIMESERIES_AZURE_AUTH_METHODS
 SARA_TIMESERIES_AZURE_CLIENT_SECRET=
 
 SARA_TIMESERIES_OTEL_EXPORTER_OTLP_ENDPOINT=None

--- a/sara_timeseries/core/credentials.py
+++ b/sara_timeseries/core/credentials.py
@@ -1,0 +1,118 @@
+import os
+from typing import Callable, Optional
+
+from azure.core.credentials import TokenCredential
+from azure.identity import (
+    AzureCliCredential,
+    ChainedTokenCredential,
+    ClientSecretCredential,
+    WorkloadIdentityCredential,
+)
+
+# Env vars injected by the workload-identity webhook on pods whose service
+# account is annotated with ``azure.workload.identity/client-id``.
+_WI_REQUIRED_ENV_VARS: tuple[str, ...] = (
+    "AZURE_TENANT_ID",
+    "AZURE_CLIENT_ID",
+    "AZURE_FEDERATED_TOKEN_FILE",
+)
+
+_SUPPORTED_METHODS: tuple[str, ...] = ("WorkloadIdentity", "AzureCli", "ClientSecret")
+
+
+def _build_workload_identity() -> Optional[TokenCredential]:
+    """Return a ``WorkloadIdentityCredential`` if WI env vars are injected.
+
+    Outside a WI-enabled pod (local dev, CI), the SDK's constructor raises
+    ``ValueError`` because the required arguments are missing. Pre-check the
+    env so the chain can fall through silently.
+    """
+    if any(not os.environ.get(v) for v in _WI_REQUIRED_ENV_VARS):
+        return None
+    return WorkloadIdentityCredential()
+
+
+def _build_azure_cli() -> Optional[TokenCredential]:
+    return AzureCliCredential()
+
+
+def _build_client_secret(
+    tenant_id: Optional[str],
+    client_id: Optional[str],
+    client_secret: Optional[str],
+) -> Optional[TokenCredential]:
+    """Return a ``ClientSecretCredential`` if all three values are set, else ``None``."""
+    if not (tenant_id and client_id and client_secret):
+        return None
+    return ClientSecretCredential(
+        tenant_id=tenant_id,
+        client_id=client_id,
+        client_secret=client_secret,
+    )
+
+
+def build_credential(
+    methods: list[str],
+    *,
+    tenant_id: Optional[str] = None,
+    client_id: Optional[str] = None,
+    client_secret: Optional[str] = None,
+) -> TokenCredential:
+    """Build a TokenCredential from an ordered list of method names.
+
+    Mirrors sara's ``AzureAd:AllowedAuthMethods`` pattern. The first
+    credential in the chain that returns a token wins; subsequent ones are
+    tried only when the previous raises ``CredentialUnavailableError``.
+
+    Limits error messages to only the configured methods (unlike
+    ``DefaultAzureCredential``, which tries seven providers and produces a
+    long composite error).
+
+    Args:
+        methods: ordered list of method names. Supported values:
+            ``"WorkloadIdentity"``, ``"AzureCli"`` and ``"ClientSecret"``.
+        tenant_id: tenant id used by ``ClientSecret``.
+        client_id: client id used by ``ClientSecret``.
+        client_secret: client secret used by ``ClientSecret``.
+
+    Returns:
+        The single underlying credential when only one method is available in
+        the current environment; otherwise a ``ChainedTokenCredential``
+        preserving the given order.
+
+    Raises:
+        ValueError: if ``methods`` is empty, contains an unknown name, or none
+            of the configured methods are available in the current environment.
+    """
+    if not methods:
+        raise ValueError(
+            "Auth methods list must not be empty. "
+            f"Supported: {list(_SUPPORTED_METHODS)}"
+        )
+
+    unknown = [m for m in methods if m not in _SUPPORTED_METHODS]
+    if unknown:
+        raise ValueError(
+            f"Unknown auth method(s): {unknown}. "
+            f"Supported: {list(_SUPPORTED_METHODS)}"
+        )
+
+    factories: dict[str, Callable[[], Optional[TokenCredential]]] = {
+        "WorkloadIdentity": _build_workload_identity,
+        "AzureCli": _build_azure_cli,
+        "ClientSecret": lambda: _build_client_secret(
+            tenant_id, client_id, client_secret
+        ),
+    }
+
+    credentials = [c for c in (factories[m]() for m in methods) if c]
+    if not credentials:
+        raise ValueError(
+            f"None of the configured auth methods are available: {methods}. "
+            f"WorkloadIdentity requires {list(_WI_REQUIRED_ENV_VARS)} env vars; "
+            "ClientSecret requires tenant_id/client_id/client_secret arguments."
+        )
+
+    if len(credentials) == 1:
+        return credentials[0]
+    return ChainedTokenCredential(*credentials)

--- a/sara_timeseries/core/settings.py
+++ b/sara_timeseries/core/settings.py
@@ -14,7 +14,19 @@ class Settings(BaseSettings):
 
     # Ego auth
     AZURE_CLIENT_ID: str = Field(default="dd7e115a-037e-4846-99c4-07561158a9cd")
+
+    # Optional client secret for the sara app registration. Only consumed when
+    # "ClientSecret" is included in AZURE_AUTH_METHODS (off by default).
     AZURE_CLIENT_SECRET: Optional[str] = Field(default=None)
+
+    # Ordered list of credential types attempted when authenticating to Azure
+    # resources (e.g. Blob Storage). The first one that yields a token wins;
+    # subsequent entries are tried only on CredentialUnavailableError. Mirrors
+    # sara's AzureAd:AllowedAuthMethods. Supported: "WorkloadIdentity",
+    # "AzureCli", "ClientSecret".
+    AZURE_AUTH_METHODS: list[str] = Field(
+        default_factory=lambda: ["WorkloadIdentity", "AzureCli"]
+    )
 
     # Service principle authentication
     TIMESERIES_CLIENT_ID: str = Field(default="38ab1ef9-d7ea-4e2b-ae4c-466ca70a1093")

--- a/sara_timeseries/modules/sara_timeseries_insights/blob_store.py
+++ b/sara_timeseries/modules/sara_timeseries_insights/blob_store.py
@@ -1,8 +1,8 @@
 import json
 
-from azure.identity import ClientSecretCredential
 from azure.storage.blob import BlobClient, BlobServiceClient, ContainerClient
 
+from sara_timeseries.core.credentials import build_credential
 from sara_timeseries.core.settings import settings
 from sara_timeseries.modules.sara_timeseries_insights.visualize_gas_concentration import (
     MapCorners,
@@ -10,10 +10,14 @@ from sara_timeseries.modules.sara_timeseries_insights.visualize_gas_concentratio
 
 
 def get_map_and_corners(facility: str) -> tuple[bytes, MapCorners]:
-    if settings.AZURE_CLIENT_SECRET is None:
-        raise ValueError("Azure client secret is not set in settings")
-
-    credentials = ClientSecretCredential(
+    # In AKS, WorkloadIdentityCredential reads the federated token mounted by
+    # the workload-identity webhook (the pod's service account is annotated
+    # with the sara app registration client ID). Locally, AzureCliCredential
+    # is used (`az login`). The chain is configurable via
+    # SARA_TIMESERIES_AZURE_AUTH_METHODS; "ClientSecret" can be added when a
+    # secret-based fallback is needed.
+    credentials = build_credential(
+        settings.AZURE_AUTH_METHODS,
         tenant_id=settings.TENANT_ID,
         client_id=settings.AZURE_CLIENT_ID,
         client_secret=settings.AZURE_CLIENT_SECRET,

--- a/tests/core/test_credentials.py
+++ b/tests/core/test_credentials.py
@@ -1,0 +1,130 @@
+from pathlib import Path
+
+import pytest
+from azure.identity import (
+    AzureCliCredential,
+    ChainedTokenCredential,
+    ClientSecretCredential,
+    WorkloadIdentityCredential,
+)
+from pytest import MonkeyPatch
+
+from sara_timeseries.core.credentials import (
+    _WI_REQUIRED_ENV_VARS,
+    build_credential,
+)
+
+
+def _set_wi_env(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
+    """Pretend we're inside a WI-enabled pod."""
+    token_file = tmp_path / "token"
+    token_file.write_text("fake-token")
+    monkeypatch.setenv("AZURE_TENANT_ID", "3aa4a235-b6e2-48d5-9195-7fcf05b459b0")
+    monkeypatch.setenv("AZURE_CLIENT_ID", "dd7e115a-037e-4846-99c4-07561158a9cd")
+    monkeypatch.setenv("AZURE_FEDERATED_TOKEN_FILE", str(token_file))
+
+
+def _clear_wi_env(monkeypatch: MonkeyPatch) -> None:
+    for v in _WI_REQUIRED_ENV_VARS:
+        monkeypatch.delenv(v, raising=False)
+
+
+def test_single_method_returns_underlying_credential(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _clear_wi_env(monkeypatch)
+    cred = build_credential(["AzureCli"])
+    assert isinstance(cred, AzureCliCredential)
+
+
+def test_multiple_methods_returns_chained_credential_in_order(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    _set_wi_env(monkeypatch, tmp_path)
+    cred = build_credential(["WorkloadIdentity", "AzureCli"])
+    assert isinstance(cred, ChainedTokenCredential)
+    inner = cred.credentials  # type: ignore[attr-defined]
+    assert isinstance(inner[0], WorkloadIdentityCredential)
+    assert isinstance(inner[1], AzureCliCredential)
+
+
+def test_workload_identity_skipped_outside_pod(monkeypatch: MonkeyPatch) -> None:
+    """WI silently drops out of the chain when env vars are absent."""
+    _clear_wi_env(monkeypatch)
+    cred = build_credential(["WorkloadIdentity", "AzureCli"])
+    assert isinstance(cred, AzureCliCredential)
+
+
+def test_client_secret_method_returns_credential(monkeypatch: MonkeyPatch) -> None:
+    _clear_wi_env(monkeypatch)
+    cred = build_credential(
+        ["ClientSecret"],
+        tenant_id="tenant",
+        client_id="client",
+        client_secret="secret",
+    )
+    assert isinstance(cred, ClientSecretCredential)
+
+
+def test_client_secret_skipped_when_secret_missing(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _clear_wi_env(monkeypatch)
+    cred = build_credential(
+        ["ClientSecret", "AzureCli"],
+        tenant_id="tenant",
+        client_id="client",
+        client_secret=None,
+    )
+    assert isinstance(cred, AzureCliCredential)
+
+
+def test_three_method_chain_preserves_order(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    _set_wi_env(monkeypatch, tmp_path)
+    cred = build_credential(
+        ["WorkloadIdentity", "ClientSecret", "AzureCli"],
+        tenant_id="tenant",
+        client_id="client",
+        client_secret="secret",
+    )
+    assert isinstance(cred, ChainedTokenCredential)
+    inner = cred.credentials  # type: ignore[attr-defined]
+    assert isinstance(inner[0], WorkloadIdentityCredential)
+    assert isinstance(inner[1], ClientSecretCredential)
+    assert isinstance(inner[2], AzureCliCredential)
+
+
+def test_empty_methods_raises_value_error() -> None:
+    with pytest.raises(ValueError, match="must not be empty"):
+        build_credential([])
+
+
+def test_unknown_method_raises_value_error() -> None:
+    with pytest.raises(ValueError, match="Unknown auth method"):
+        build_credential(["ManagedIdentity"])
+
+
+def test_unknown_method_error_lists_supported() -> None:
+    with pytest.raises(ValueError, match="ClientSecret"):
+        build_credential(["Bogus"])
+
+
+def test_only_wi_with_no_env_raises_value_error(monkeypatch: MonkeyPatch) -> None:
+    _clear_wi_env(monkeypatch)
+    with pytest.raises(ValueError, match="None of the configured auth methods"):
+        build_credential(["WorkloadIdentity"])
+
+
+def test_only_client_secret_without_secret_raises_value_error(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _clear_wi_env(monkeypatch)
+    with pytest.raises(ValueError, match="None of the configured auth methods"):
+        build_credential(
+            ["ClientSecret"],
+            tenant_id="tenant",
+            client_id="client",
+            client_secret=None,
+        )


### PR DESCRIPTION
Replaces `ClientSecretCredential` in `blob_store.get_map_and_corners` with an explicit `ChainedTokenCredential` built from a new `core/credentials.py` helper. The chain is driven by a new `AZURE_AUTH_METHODS` settings field (default `["WorkloadIdentity", "AzureCli"]`, overridable via `SARA_TIMESERIES_AZURE_AUTH_METHODS`). Mirrors sara's `AzureAd:AllowedAuthMethods` pattern. Supported methods: `WorkloadIdentity`, `AzureCli`, `ClientSecret`. In AKS, `WorkloadIdentityCredential` reads the federated token mounted by the workload-identity webhook (the pod's service account `robotics-analytics-sa` is annotated with the sara app registration client ID per env); locally, `AzureCliCredential` is used (`az login`). Methods are silently skipped when their prerequisites are absent so the chain falls through cleanly.

`AZURE_CLIENT_SECRET` is kept as an optional setting (default `None`) and is only consumed when `ClientSecret` is explicitly added to `AZURE_AUTH_METHODS`. This preserves a secret-based fallback for local dev or break-glass scenarios without making it part of the default chain. Combined with the matching analytics-infrastructure change, lets us drop the SPC mapping `TIMESERIES_SARA_CLIENT_SECRET` and ultimately remove the secret from Key Vault.