### PR TITLE
ACR migration: Dual-push images to per-env robotics ACRs alongside Aurora

### DIFF
--- a/.github/workflows/deploy_to_staging.yml
+++ b/.github/workflows/deploy_to_staging.yml
@@ -64,6 +64,23 @@ jobs:
       registry_username: ${{ secrets.ROBOTICS_AURORAPRODACR_USERNAME }}
       registry_password: ${{ secrets.ROBOTICS_AURORAPRODACR_PASSWORD }}
 
+  build-and-push-latest-release-image-to-robotics-staging-container-registry:
+    name: Build and push latest release image to robotics staging container registry
+    uses: equinor/armada/.github/workflows/build_and_publish_docker_image_to_container_registry.yml@main
+    permissions:
+      contents: read
+      packages: write
+    with:
+      registry: roboticsstagingacr.azurecr.io
+      image_name: robotics/sara-timeseries
+      tag: ${{ github.event.release.tag_name }}
+      secondary_tag: latest
+      path_to_dockerfile: Dockerfile
+      path_to_context: .
+    secrets:
+      registry_username: ${{ secrets.ROBOTICS_ROBOTICSSTAGINGACR_USERNAME }}
+      registry_password: ${{ secrets.ROBOTICS_ROBOTICSSTAGINGACR_PASSWORD }}
+
   update-deployment-in-staging:
     name: Update deployment in Staging
     needs: build-and-push-latest-release-image-to-aurora-prod-container-registry

--- a/.github/workflows/promote_to_production.yml
+++ b/.github/workflows/promote_to_production.yml
@@ -29,9 +29,35 @@ jobs:
           VERSION_TAG=$(sed -n "${TAG_LINE_NUMBER}p" k8s_kustomize/overlays/staging/kustomization.yaml  |  cut --delimiter=":" --fields=2)
           echo "tag=$VERSION_TAG" >> "$GITHUB_OUTPUT"
 
+  copy-image-to-robotics-prod-registry:
+    name: Copy staging image to robotics prod registry
+    needs: get_staging_version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log in to robotics staging registry
+        uses: docker/login-action@v3
+        with:
+          registry: roboticsstagingacr.azurecr.io
+          username: ${{ secrets.ROBOTICS_ROBOTICSSTAGINGACR_USERNAME }}
+          password: ${{ secrets.ROBOTICS_ROBOTICSSTAGINGACR_PASSWORD }}
+
+      - name: Log in to robotics prod registry
+        uses: docker/login-action@v3
+        with:
+          registry: roboticsprodacr.azurecr.io
+          username: ${{ secrets.ROBOTICS_ROBOTICSPRODACR_USERNAME }}
+          password: ${{ secrets.ROBOTICS_ROBOTICSPRODACR_PASSWORD }}
+
+      - name: Copy image from staging to prod registry
+        run: |
+          docker buildx imagetools create \
+            --tag roboticsprodacr.azurecr.io/robotics/sara-timeseries:${{ needs.get_staging_version.outputs.versionTag }} \
+            --tag roboticsprodacr.azurecr.io/robotics/sara-timeseries:latest \
+            roboticsstagingacr.azurecr.io/robotics/sara-timeseries:${{ needs.get_staging_version.outputs.versionTag }}
+
   deploy:
     name: Update deployment in Production
-    needs: get_staging_version
+    needs: [get_staging_version, copy-image-to-robotics-prod-registry]
     uses: equinor/armada/.github/workflows/update_kubernetes_deployment.yml@main
     with:
       environment: production


### PR DESCRIPTION
Migrates image builds off Aurora ACR to per-env robotics ACRs alongside the existing Aurora jobs during migration.

**Model**

- `deploy_to_staging.yml`: on release, also push the `robotics/sara-timeseries` image to `roboticsstagingacr.azurecr.io`.
- `promote_to_production.yml`: adds a `copy-image-to-robotics-prod-registry` job that uses `docker buildx imagetools create` to copy the image tag from `roboticsstagingacr` \u2192 `roboticsprodacr` (no rebuild), then the existing deploy job patches the production overlay.

Dev workflow is unchanged \u2014 already dual-pushes to ghcr and Aurora dev. Analytics dev overlay will retarget from `auroradevacr` to `ghcr.io` in a follow-up PR on equinor/analytics-infrastructure.

Aurora push jobs are preserved during migration and will be dropped in a follow-up PR after all analytics overlays retarget to robotics ACRs.

Requires repo secrets: `ROBOTICS_ROBOTICS{STAGING,PROD}ACR_{USERNAME,PASSWORD}` \u2014 provisioned by `automation/aks/provision-acr-push-tokens.sh` in equinor/robotics-infrastructure#1054.

Part of container registry migration off Aurora (equinor/robotics-infrastructure#1009).