### PR TITLE
CI: Update dev overlay from ghcr instead of auroradevacr

### DIFF
--- a/.github/workflows/deploy_to_development.yml
+++ b/.github/workflows/deploy_to_development.yml
@@ -50,8 +50,8 @@ jobs:
       contents: read
       packages: write
     with:
-      registry: auroradevacr.azurecr.io
-      image_name: robotics/sara-timeseries
+      registry: ghcr.io
+      image_name: ${{ github.repository }}
       tag: "dev.${{ needs.get-short-sha.outputs.tag }}"
       secondary_tag: dev
       path_to_dockerfile: Dockerfile
@@ -62,12 +62,12 @@ jobs:
 
   deploy:
     name: Update deployment in Development
-    needs: [build-and-push-dev-image-to-aurora-container-registry, get-short-sha]
+    needs: [build-and-push-dev-image-to-ghcr, get-short-sha]
     uses: equinor/armada/.github/workflows/update_kubernetes_deployment.yml@main
     with:
       environment: development
-      registry: auroradevacr.azurecr.io
-      image_name: robotics/sara-timeseries
+      registry: ghcr.io
+      image_name: ${{ github.repository }}
       tag: "dev.${{ needs.get-short-sha.outputs.tag }}"
       author_email: ${{ github.event.head_commit.author.email }}
       author_name: ${{ github.event.head_commit.author.name }}


### PR DESCRIPTION
## Summary
- Point the `Update deployment in Development` job at the ghcr build instead of the auroradevacr build (`registry`, `image_name`, and `needs` updated).

## Why
Pairs with equinor/analytics-infrastructure#319 which retargets the dev overlay's `newName` for every SARA image to `ghcr.io/equinor/*`. Until this merges *and* #319 is merged, next dev push will fail the `Update deployment` step because armada looks for the old `auroradevacr.azurecr.io/robotics/*` string, which #319 replaced. Failure is non-destructive.

Follow-up cleanup (not in this PR): the parallel aurora-dev build job is now dead code (Aurora dev overlay will also pull from ghcr after #319) and can be deleted.