### PR TITLE
CI: Remove obsolete auroradevacr dev build job

### DIFF
--- a/.github/workflows/deploy_to_development.yml
+++ b/.github/workflows/deploy_to_development.yml
@@ -42,24 +42,6 @@ jobs:
       registry_username: ${{ github.actor }}
       registry_password: ${{ secrets.GITHUB_TOKEN }}
 
-  build-and-push-dev-image-to-aurora-container-registry:
-    name: Build and push dev image to aurora container registry
-    needs: [get-short-sha]
-    uses: equinor/armada/.github/workflows/build_and_publish_docker_image_to_container_registry.yml@main
-    permissions:
-      contents: read
-      packages: write
-    with:
-      registry: ghcr.io
-      image_name: ${{ github.repository }}
-      tag: "dev.${{ needs.get-short-sha.outputs.tag }}"
-      secondary_tag: dev
-      path_to_dockerfile: Dockerfile
-      path_to_context: .
-    secrets:
-      registry_username: ${{ secrets.ROBOTICS_AURORADEVACR_USERNAME }}
-      registry_password: ${{ secrets.ROBOTICS_AURORADEVACR_PASSWORD }}
-
   deploy:
     name: Update deployment in Development
     needs: [build-and-push-dev-image-to-ghcr, get-short-sha]


### PR DESCRIPTION
## Summary
- Remove the `build-and-push-dev-image-to-aurora-container-registry` job from `deploy_to_development.yml`. It was writing to `ghcr.io` (after the recent overlay retarget) but authenticating with the auroradevacr username/password, causing `denied: denied` on every dev push.
- The parallel `build-and-push-dev-image-to-ghcr` job already produces the same image with the same tag, so no build coverage is lost.

## Why
Introduced as fallout from the earlier "point dev overlay at ghcr" batch: the aurora-registry job was rewritten to target `ghcr.io` but its secrets block was not, so authentication fails.

Aurora dev's overlay was retargeted to `ghcr.io/equinor/*` in equinor/analytics-infrastructure#319, so there is no longer any consumer of the auroradevacr dev tag.