### PR TITLE
Retarget staging and prod deployments to robotics registries

### DIFF
--- a/.github/workflows/deploy_to_staging.yml
+++ b/.github/workflows/deploy_to_staging.yml
@@ -47,23 +47,6 @@ jobs:
       registry_username: ${{ github.actor }}
       registry_password: ${{ secrets.GITHUB_TOKEN }}
 
-  build-and-push-latest-release-image-to-aurora-prod-container-registry:
-    name: Build and push latest release image to aurora prod container registry
-    uses: equinor/armada/.github/workflows/build_and_publish_docker_image_to_container_registry.yml@main
-    permissions:
-      contents: read
-      packages: write
-    with:
-      registry: auroraprodacr.azurecr.io
-      image_name: robotics/sara-timeseries
-      tag: ${{ github.event.release.tag_name }}
-      secondary_tag: latest
-      path_to_dockerfile: Dockerfile
-      path_to_context: .
-    secrets:
-      registry_username: ${{ secrets.ROBOTICS_AURORAPRODACR_USERNAME }}
-      registry_password: ${{ secrets.ROBOTICS_AURORAPRODACR_PASSWORD }}
-
   build-and-push-latest-release-image-to-robotics-staging-container-registry:
     name: Build and push latest release image to robotics staging container registry
     uses: equinor/armada/.github/workflows/build_and_publish_docker_image_to_container_registry.yml@main
@@ -83,11 +66,11 @@ jobs:
 
   update-deployment-in-staging:
     name: Update deployment in Staging
-    needs: build-and-push-latest-release-image-to-aurora-prod-container-registry
+    needs: build-and-push-latest-release-image-to-robotics-staging-container-registry
     uses: equinor/armada/.github/workflows/update_kubernetes_deployment.yml@main
     with:
       environment: staging
-      registry: auroraprodacr.azurecr.io
+      registry: roboticsstagingacr.azurecr.io
       image_name: robotics/sara-timeseries
       tag: ${{ github.event.release.tag_name }}
       author_name: ${{ github.event.release.author.login }}

--- a/.github/workflows/promote_to_production.yml
+++ b/.github/workflows/promote_to_production.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Get Sara Timeseries version in staging
         id: get_version_tag
         run: |
-          TAG_LINE_NUMBER=$(($(grep -n "auroraprodacr.azurecr.io/robotics/sara-timeseries" k8s_kustomize/overlays/staging/kustomization.yaml |  cut --delimiter=":" --fields=1)+1))
+          TAG_LINE_NUMBER=$(($(grep -n "roboticsstagingacr.azurecr.io/robotics/sara-timeseries" k8s_kustomize/overlays/staging/kustomization.yaml |  cut --delimiter=":" --fields=1)+1))
           VERSION_TAG=$(sed -n "${TAG_LINE_NUMBER}p" k8s_kustomize/overlays/staging/kustomization.yaml  |  cut --delimiter=":" --fields=2)
           echo "tag=$VERSION_TAG" >> "$GITHUB_OUTPUT"
 
@@ -62,7 +62,7 @@ jobs:
     with:
       environment: production
       tag: ${{ needs.get_staging_version.outputs.versionTag }}
-      registry: auroraprodacr.azurecr.io
+      registry: roboticsprodacr.azurecr.io
       image_name: robotics/sara-timeseries
       author_name: ${{ github.actor }}
       infrastructure_repository: equinor/analytics-infrastructure


### PR DESCRIPTION
## Summary
- Drop the `auroraprodacr` build job from `deploy_to_staging.yml`; retarget the staging deploy to the `roboticsstagingacr` build
- Retarget `promote_to_production.yml` staging-version lookup to `roboticsstagingacr` and prod deploy to `roboticsprodacr`

Part of equinor/robotics-infrastructure#1009.